### PR TITLE
Update entrypoint to avoid errors

### DIFF
--- a/phpstan-drupal/Dockerfile
+++ b/phpstan-drupal/Dockerfile
@@ -3,4 +3,4 @@ WORKDIR /opt/phpstan
 RUN composer require 'mglaman/phpstan-drupal:0.11.7'
 WORKDIR /app
 VOLUME /app
-ENTRYPOINT ["/opt/phpstan/vendor/bin/phpstan" "analyse" "-c /opt/phpstan/vendor/mglaman/phpstan-drupal/extension.neon"]
+ENTRYPOINT [ "/opt/phpstan/vendor/bin/phpstan", "analyse", "-c", "/opt/phpstan/vendor/mglaman/phpstan-drupal/extension.neon" ]


### PR DESCRIPTION
Without this change we get:

    $ docker run --rm mparker17/phpstan-drupal
    /bin/sh: [/opt/phpstan/vendor/bin/phpstan: not found

With this change we get:

    At least one path must be specified to analyse.

as expected
