### PR TITLE
Add stylelint Dockerfile.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This repository has several Docker images for Drupal code quality analysis...
 * `eslint-es6-drupal` which runs Drupal's ECMAScript 6 coding standards lints,
 * `phpcs-drupal` which runs Drupal's coding standards lints,
 * `phpcs-drupalpractice` which runs Drupal's best practices lints,
+* `stylelint` which runs Drupal's CSS coding standards lints,
 
 As well as some other useful tools...
 * `dephpend` which performs dependency analysis on a PHP project and its classes,
@@ -30,6 +31,7 @@ docker build -t phpcs-drupal ./phpcs-drupal/
 docker build -t phpcbf-drupal ./phpcbf-drupal/
 docker build -t phpcs-drupalpractice ./phpcs-drupalpractice/
 docker build -t phpcbf-drupalpractice ./phpcbf-drupalpractice/
+docker build -t stylelint ./stylelint/
 
 docker build -t dephpend ./dephpend/
 docker build -t jsonlint ./jsonlint/
@@ -49,6 +51,7 @@ docker run --rm -v $PWD:/app phpcs-drupal $path_to_lint # --report=summary
 docker run --rm -v $PWD:/app phpcbf-drupal $path_to_lint
 docker run --rm -v $PWD:/app phpcs-drupalpractice $path_to_lint # --report=summary
 docker run --rm -v $PWD:/app phpcbf-drupalpractice $path_to_lint
+docker run --rm -v $PWD:/app stylelint $path_to_lint
 
 docker run --rm -v $PWD:/app dephpend text $path_to_lint
 docker run --rm -v $PWD:/app jsonlint $path_to_lint
@@ -69,6 +72,7 @@ docker run --rm -v $PWD:/app mparker17/phpcbf-drupalpractice $path_to_lint
 
 docker run --rm -v $PWD:/app mparker17/dephpend text $path_to_lint
 docker run --rm -v $PWD:/app mparker17/jsonlint $path_to_lint
+docker run --rm -v $PWD:/app mparker17/stylelint $path_to_lint
 docker run --rm -v $PWD:/app mparker17/phpcpd $path_to_lint
 docker run --rm -v $PWD:/app mparker17/phpmetrics $path_to_lint
 docker run --rm -v $PWD:/app mparker17/phpstan-drupal $path_to_lint

--- a/stylelint/Dockerfile
+++ b/stylelint/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:10.15
+WORKDIR /opt/drupal
+RUN curl -o 'package.json' -L 'https://git.drupalcode.org/project/drupal/-/raw/8a9f88169a7c3b6a00636d5e0c4c9f8988d92499/core/package.json' && \
+  npm install && \
+  curl -o '.stylelintrc.json' -L 'https://git.drupalcode.org/project/drupal/-/raw/8a9f88169a7c3b6a00636d5e0c4c9f8988d92499/core/.stylelintrc.json'
+WORKDIR /app
+VOLUME /app
+ENTRYPOINT ["/opt/drupal/node_modules/.bin/stylelint", "--config", "/opt/drupal/.stylelintrc.json"]


### PR DESCRIPTION
Extend the Drupal docker images for the Drupal community. This one has package and stylelint configuration files from Drupal 8.8.x